### PR TITLE
Customize placeholders for Best Roofing Now

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ Below are a few features we have implemented to date:
 
   Thanks to these amazing services that we use and recommend for UI testing (Chromatic), code review (Greptile), catching bugs (Sentry) and translating (Crowdin).
 
+## Custom Setup for Best Roofing Now
+
+This fork demonstrates how Twenty can be configured for a specific business. Example values used in the documentation have been replaced with information for **Best Roofing Now**.
+
+- Workspace domain: `bestroofingnow.com`
+- Contact email: `contact@bestroofingnow.com`
+
+Update your `.env` files and workspace settings with values that match your own organization.
+
 
 # Join the Community
 

--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -122,7 +122,7 @@ export const SettingsSecurityApprovedAccessDomain = () => {
                     onChange(domain);
                   }}
                   fullWidth
-                  placeholder="yourdomain.com"
+                  placeholder="bestroofingnow.com"
                   error={error?.message}
                 />
               )}
@@ -146,7 +146,7 @@ export const SettingsSecurityApprovedAccessDomain = () => {
                   onChange={onChange}
                   fullWidth
                   error={error?.message}
-                  rightAdornment={`@${domain.length !== 0 ? domain : 'your-domain.com'}`}
+                  rightAdornment={`@${domain.length !== 0 ? domain : 'bestroofingnow.com'}`}
                 />
               )}
             />

--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomain.tsx
@@ -73,7 +73,7 @@ export const SettingsCustomDomain = () => {
               value={value}
               type="text"
               onChange={onChange}
-              placeholder="crm.yourdomain.com"
+              placeholder="crm.bestroofingnow.com"
               error={error?.message}
               fullWidth
             />

--- a/packages/twenty-website/src/content/developers/self-hosting/setup.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/setup.mdx
@@ -208,9 +208,9 @@ yarn command:prod cron:workflow:automated-cron-trigger
 <ArticleTable options={[
     ['IS_EMAIL_VERIFICATION_REQUIRED', 'false', 'If enabled, users must verify their email address before signing in. When true, users will receive a verification email after registration'],
     ['EMAIL_VERIFICATION_TOKEN_EXPIRES_IN', '1h', 'How long email verification tokens remain valid before requiring a new verification email'],
-    ['EMAIL_FROM_ADDRESS', 'contact@yourdomain.com', 'Global email From: header used to send emails'],
-    ['EMAIL_FROM_NAME', 'John from YourDomain', 'Global name From: header used to send emails'],
-    ['EMAIL_SYSTEM_ADDRESS', 'system@yourdomain.com', 'Email address used as a destination to send internal system notification'],
+    ['EMAIL_FROM_ADDRESS', 'contact@bestroofingnow.com', 'Global email From: header used to send emails'],
+    ['EMAIL_FROM_NAME', 'John from Best Roofing Now', 'Global name From: header used to send emails'],
+    ['EMAIL_SYSTEM_ADDRESS', 'system@bestroofingnow.com', 'Email address used as a destination to send internal system notification'],
     ['EMAIL_DRIVER', 'logger', "Email driver: 'logger' (to log emails in console) or 'smtp'"],
     ['EMAIL_SMTP_HOST', '', 'Email SMTP Host'],
     ['EMAIL_SMTP_PORT', '', 'Email SMTP Port'],

--- a/packages/twenty-website/src/content/twenty-ui/navigation/links.mdx
+++ b/packages/twenty-website/src/content/twenty-ui/navigation/links.mdx
@@ -24,10 +24,10 @@ export const MyComponent = () => {
     <Router>
       <ContactLink
         className
-        href="mailto:example@example.com"
+        href="mailto:contact@bestroofingnow.com"
         onClick={handleLinkClick}
       >
-        example@example.com
+        contact@bestroofingnow.com
       </ContactLink>
     </Router>
   );


### PR DESCRIPTION
## Summary
- replace generic email placeholders with `contact@bestroofingnow.com`
- show Best Roofing Now domain in custom domain settings
- set Best Roofing Now placeholders in security settings
- update self‑hosting doc with Best Roofing Now email examples
- document custom setup in README

## Testing
- `yarn --version` *(fails: Error when performing the request)*